### PR TITLE
Typo fix for broken link v5->v6

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ function showManualUpdateMessage(hooks: { [key: string]: string }) {
   commitlint -E HUSKY_GIT_PARAMS → npx --no-install commitlint --edit $1
                                  → yarn commitlint --edit $1
 
-See {underline https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v5}
+See {underline https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v6}
 `)
   }
 }


### PR DESCRIPTION
https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v6 is the correct link