### PR TITLE
State minimum NPM version, change added version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,28 +8,28 @@ If your `package.json` is not at the same level as `.git`, please update manuall
 
 ## Usage
 
-### npm
+### npm (7+)
 
 ```shell
-npm install husky@6 --save-dev \
+npm install husky@^6.0 --save-dev \
   && npx husky-init \
   && npm exec -- github:typicode/husky-4-to-6 --remove-v4-config
 ```
 
 ### yarn
 
-Yarn 1
+Yarn 1 (requires npm 7+ for `npm exec`)
 
 ```shell
-yarn add husky@6 --dev \
+yarn add husky@^6.0 --dev \
   && npx husky-init \
   && npm exec -- github:typicode/husky-4-to-6 --remove-v4-config
 ```
 
-Yarn 2
+Yarn 2 (requires npm 7+ for `npm exec`)
 
 ```shell
-yarn add husky@6 --dev \
+yarn add husky@^6.0 --dev \
   && yarn dlx husky-init --yarn2 \
   && npm exec -- github:typicode/husky-4-to-6 --remove-v4-config
 ```


### PR DESCRIPTION
NPM <7 doesn't work because exec doesn't exist. Therefore it might be a good idea to have it stated. In addition to that it would be better to use a caret range for version 6.