### PR TITLE
Add documentation for pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ yarn add husky@6 --dev \
   && npm exec -- github:typicode/husky-4-to-6 --remove-v4-config
 ```
 
+### pnpm
+
+`pnpm exec` doesn't support executing code from github, but you can use `npm exec` to do so:
+
+```shell
+pnpm install husky@6 --save-dev \
+  && pnpx husky-init \
+  && npm exec -- github:typicode/husky-4-to-6 --remove-v4-config
+```
+
 ## What each command does
 
 `husky init` sets up Git hooks and updates your `package.json` scripts (you may want to commit your changes to `package.json` before running `husky init`).

--- a/README.md
+++ b/README.md
@@ -36,12 +36,10 @@ yarn add husky@6 --dev \
 
 ### pnpm
 
-`pnpm exec` doesn't support executing code from github, but you can use `npm exec` to do so:
-
 ```shell
 pnpm install husky@6 --save-dev \
   && pnpx husky-init \
-  && npm exec -- github:typicode/husky-4-to-6 --remove-v4-config
+  && pnpx -- github:typicode/husky-4-to-6 --remove-v4-config
 ```
 
 ## What each command does


### PR DESCRIPTION
Pnpm doesn't support executing code from github via `pnpm exec`, so I used `pnpx` instead